### PR TITLE
Teleporting lines

### DIFF
--- a/pathgenerator/models/coordinate.py
+++ b/pathgenerator/models/coordinate.py
@@ -32,6 +32,11 @@ class Coordinate:
         return (x, z)
 
     @property
+    def coord_2d_unscaled(self):
+        """Get a tuple of the unscaled 2d coordinates"""
+        return (self.x, self.z)
+
+    @property
     def coord_3d(self):
         """
         Scales the Coordinate to a scaled 3d coordinate
@@ -42,6 +47,11 @@ class Coordinate:
         """
         x, z = self.coord_2d
         return (x, self.y, z)
+
+    @property
+    def coord_3d_unscaled(self):
+        """Get a tuple of the unscaled 3d coordinates"""
+        return (self.x, self.y, self.z)
 
     @property
     def is_inside_view(self):

--- a/pathgenerator/utils/map_drawer.py
+++ b/pathgenerator/utils/map_drawer.py
@@ -131,14 +131,15 @@ def draw_positions(pos_data):
         for world in WORLDS[coord.world_name]:
             coord.world = world
             prev_coord.world = world
+            dist = np.linalg.norm(np.array(coord.coord_3d_unscaled) - np.array(prev_coord.coord_3d_unscaled))
 
             # If we switched maps, finish the path by drawing a red dot at the stopping position
-            if different_world:
+            # We also want to finish the path if the player seemingly teleported (point dist. > 50)
+            if different_world or dist > 50:
                 # Finish off the previous image path
                 dot(prev_coord.world.draw_obj, prev_coord, 'red')
                 continue
 
-            dist = np.linalg.norm(np.array(coord.coord_3d) - np.array(prev_coord.coord_3d))
             counts[world.display_name] += dist
 
             map_draw = world.draw_obj

--- a/pathgenerator/utils/map_drawer.py
+++ b/pathgenerator/utils/map_drawer.py
@@ -187,7 +187,7 @@ def draw_observations(obs_data):
             dot(map_draw, coord, 'red')
 
             # The coordinate's "data" is the text of the observation
-            drawText(map_draw, coord.coord_2d, coord.data)
+            drawText(map_draw, coord.coord_2d, str(coord.data))
             counts[world.display_name] += 1
 
     return counts


### PR DESCRIPTION
* Added `coord_2d_unscaled` and `coord_3d_unscaled` properties for `Coordinate`
* Properly calculating distance between points in _Minecraft_ blocks (it used to be a weird combination of pixels and blocks)
* If two points are more than 50 blocks apart, a line is not drawn. This is to prevent lines from being drawn when the player teleports